### PR TITLE
Fixed wdisable calculation + Hide dropped items in dimension

### DIFF
--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -628,7 +628,7 @@ void TossClientWeapon(gentity_t *self, const vec3_t direction, float speed)
 	vel[1] = direction[1]*speed;
 	vel[2] = direction[2]*speed;
 
-	launched = LaunchItem(item, self->client->ps.origin, vel);
+	launched = LaunchItem(item, self->client->ps.origin, vel, self->s.number);
 
 	launched->s.generic1 = self->s.number;
 	launched->s.powerups = level.time + 1500;

--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -1616,10 +1616,10 @@ LaunchItem
 Spawns an item and tosses it forward
 ================
 */
-gentity_t *LaunchItem( gitem_t *item, vec3_t origin, vec3_t velocity ) {
+gentity_t *LaunchItem( gitem_t *item, vec3_t origin, vec3_t velocity, int blameEntityNum ) {
 	gentity_t	*dropped;
 
-	dropped = G_Spawn( ENTITYNUM_WORLD );
+	dropped = G_Spawn( blameEntityNum );
 
 	dropped->s.eType = ET_ITEM;
 	dropped->s.modelindex = item - bg_itemlist;	// store item number in modelindex
@@ -1712,7 +1712,7 @@ gentity_t *Drop_Item( gentity_t *ent, gitem_t *item, float angle ) {
 	VectorScale( velocity, 150, velocity );
 	velocity[2] += 200 + crandom() * 50;
 
-	return LaunchItem( item, ent->s.pos.trBase, velocity );
+	return LaunchItem( item, ent->s.pos.trBase, velocity, ent->s.number );
 }
 
 

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -743,7 +743,7 @@ void RespawnItem( gentity_t *ent );
 void UseHoldableItem( gentity_t *ent );
 void PrecacheItem (gitem_t *it);
 gentity_t *Drop_Item( gentity_t *ent, gitem_t *item, float angle );
-gentity_t *LaunchItem( gitem_t *item, vec3_t origin, vec3_t velocity );
+gentity_t *LaunchItem( gitem_t *item, vec3_t origin, vec3_t velocity, int blameEntityNum );
 void SetRespawn (gentity_t *ent, float delay);
 void G_SpawnItem (gentity_t *ent, gitem_t *item);
 void FinishSpawningItem( gentity_t *ent );

--- a/cvar-calculator.html
+++ b/cvar-calculator.html
@@ -20,6 +20,9 @@
        min-width: 200px;
        font-weight: bold;
      }
+     .hidden {
+       display: none;
+     }
     </style>
   </head>
 
@@ -63,6 +66,7 @@
         <input type="button" class="select-none" value="None" />
       </p>
       <div class="bitboxes">
+        <div class="hidden"><input type="checkbox" num="0" /> None</div>
         <div><input type="checkbox" num="1" /> Stun Baton</div>
         <div><input type="checkbox" num="2" /> Lightsaber</div>
         <div><input type="checkbox" num="3" /> Blaster Pistol</div>
@@ -76,6 +80,8 @@
         <div><input type="checkbox" num="11" /> Thermal Detonators</div>
         <div><input type="checkbox" num="12" /> Trip Mines</div>
         <div><input type="checkbox" num="13" /> Detonation Packs</div>
+        <div class="hidden"><input type="checkbox" num="14" /> Emplaced Gun</div>
+        <div class="hidden"><input type="checkbox" num="15" /> Turret Gun</div>
       </div>
     </div>
 
@@ -87,6 +93,7 @@
         <input type="button" class="select-none" value="None" />
       </p>
       <div class="bitboxes">
+        <div class="hidden"><input type="checkbox" num="0" /> None</div>
         <div><input type="checkbox" num="1" /> Stun Baton</div>
         <div><input type="checkbox" num="2" /> Lightsaber</div>
         <div><input type="checkbox" num="3" /> Blaster Pistol</div>
@@ -100,6 +107,8 @@
         <div><input type="checkbox" num="11" /> Thermal Detonators</div>
         <div><input type="checkbox" num="12" /> Trip Mines</div>
         <div><input type="checkbox" num="13" /> Detonation Packs</div>
+        <div class="hidden"><input type="checkbox" num="14" /> Emplaced Gun</div>
+        <div class="hidden"><input type="checkbox" num="15" /> Turret Gun</div>
       </div>
     </div>
 


### PR DESCRIPTION
- Missing weapons on the cvar generator list causes unwanted results
- Dropped items from another dimensions are still beign seen from private duel